### PR TITLE
[PROGRAMMERS] 숫자 문자열과 영단어

### DIFF
--- a/태빈/go/programers/programer_26.go
+++ b/태빈/go/programers/programer_26.go
@@ -1,0 +1,40 @@
+package coding
+
+import (
+	"bytes"
+	"strconv"
+)
+
+func TranslateString(s string) int {
+	var result int
+	var resultByte bytes.Buffer
+	numberDict := map[string]string{
+		"zero":"0",
+		"one":"1",
+		"two":"2",
+		"three":"3",
+		"four":"4",
+		"five":"5",
+		"six":"6",
+		"seven":"7",
+		"eight":"8",
+		"nine":"9",
+	}
+	runes := []rune(s)
+	var b bytes.Buffer
+	for i:=0; i < len(runes); i++ {
+		r := runes[i]
+		if r >47 && r <58{
+			resultByte.WriteRune(r)
+			continue
+		}
+		b.WriteRune(r)
+		v, f := numberDict[b.String()]
+		if(f){
+			resultByte.WriteString(v)
+			b = *bytes.NewBuffer([]byte(""))
+		}
+	}
+	result, _ = strconv.Atoi(resultByte.String())
+	return result
+}

--- a/태빈/go/programers/programer_26_test.go
+++ b/태빈/go/programers/programer_26_test.go
@@ -1,0 +1,51 @@
+package coding
+
+import "testing"
+
+func TestTranslateString(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		// TODO: Add test cases.
+		{
+			name: "case1",
+			args: args{
+				s: "one4seveneight",
+			},
+			want: 1478,
+		},
+		{
+			name: "case2",
+			args: args{
+				s: "23four5six7",
+			},
+			want: 234567,
+		},
+		{
+			name: "case3",
+			args: args{
+				s: "2three45sixseven",
+			},
+			want: 234567,
+		},
+		{
+			name: "case4",
+			args: args{
+				s: "123",
+			},
+			want: 123,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TranslateString(tt.args.s); got != tt.want {
+				t.Errorf("TranslateString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Coding Test Study Pull Request

---

## 문제 정보

### 문제 링크
- [숫자 문자열과 영단어](https://school.programmers.co.kr/learn/courses/30/lessons/81301)

### 문제 관련 알고리즘 or 자료구조
- 구현

## 해결 과정

### 작성 코드
```go
func TranslateString(s string) int {
	var result int
	var resultByte bytes.Buffer

        // map을 활용해서 영어를 키로, 숫자를 value로 지정
	numberDict := map[string]string{
		"zero":"0",
		"one":"1",
		"two":"2",
		"three":"3",
		"four":"4",
		"five":"5",
		"six":"6",
		"seven":"7",
		"eight":"8",
		"nine":"9",
	}
	runes := []rune(s)
	var b bytes.Buffer
	for i:=0; i < len(runes); i++ {
		r := runes[I]

                // 문자별 ascii code 체크 하기
		if r >47 && r <58{
			resultByte.WriteRune(r)
			continue
		}

		b.WriteRune(r)
		v, f := numberDict[b.String()]

                // map에 해당 키가 있는지 체크하여 있을 경우에만 진행
		if(f){
			resultByte.WriteString(v)
			b = *bytes.NewBuffer([]byte(""))
		}
	}
        // 문자열을 숫자로 변환
	result, _ = strconv.Atoi(resultByte.String())
	return result
}
```

### 어려웠던 점
- 문자를 읽는 기준을 정하기 어려웠던 거 같습니다.
- ascii code를 활용하여 숫자와 문자를 구분함으써 이를 해결할 수 있습니다.
- unicode를 활용하면 좀 더 깔끔한 코드가 나올 것으로 보입니다.

### 궁금한 점

- 없음

### 기타
-  없음
